### PR TITLE
Adds weekday as a feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The features to be extracted can be configured with the following optional param
 - `--hashtag_num`: Count the number of hashtags in the "hashtags" column of the data frame. (see code.feature_extraction/hashtag_num.py)
 - `-m` or `--mention_num`: Count the number of mentions in the "mentions" column of the data frame. (see code.feature_extraction/mention_num.py)
 - `-u` or `--url_num`: Count the number of URLs in the "urls" column of the data frame. (see code.feature_extraction/url_num.py)
-
+- `-w` or `--weekday`: Extract the one-hot-encoded weekday from the "date" column of the data frame (see code.feature_extraction/weekday_extractor.py)
 Moreover, the script support importing and exporting fitted feature extractors with the following optional arguments:
 - `-i` or `--import_file`: Load a configured and fitted feature extraction from the given pickle file. Ignore all parameters that configure the features to extract.
 - `-e` or `--export_file`: Export the configured and fitted feature extraction into the given pickle file.

--- a/code/feature_extraction/extract_features.py
+++ b/code/feature_extraction/extract_features.py
@@ -19,8 +19,6 @@ from code.feature_extraction.hashtag_num import HashtagNum
 from code.feature_extraction.url_num import URLsNum
 from code.feature_extraction.cap_letter_num import CapLettersNum
 from code.feature_extraction.punc_num import PunctuationNum
-from code.util import COLUMN_TWEET, COLUMN_LABEL, COLUMN_HASHTAGS, COLUMN_MENTIONS, COLUMN_URLS
-from code.feature_extraction.tweet_language import TweetLanguage
 from code.feature_extraction.weekday_extractor import WeekdayExtractor
 from code.util import COLUMN_TWEET, COLUMN_LABEL, COLUMN_HASHTAGS, COLUMN_MENTIONS, COLUMN_URLS, COLUMN_DATE
 
@@ -37,7 +35,6 @@ parser.add_argument("-m", "--mention_num", action="store_true", help="compute th
 parser.add_argument("-u", "--url_num", action="store_true", help="compute the number of URLs in the tweet")
 parser.add_argument("--cap_letter", action="store_true", help="compute the number of capital letters in the tweet")
 parser.add_argument("-p", "--punc_num", action="store_true", help="compute the number punctuation characters in the tweet")
-
 parser.add_argument("-w", "--weekday", action="store_true", help="extract the one-hot encoded weekday of the tweet's date")
 args = parser.parse_args()
 
@@ -75,6 +72,7 @@ else:  # need to create FeatureCollector manually
         features.append(CapLettersNum(COLUMN_TWEET))
         # number of capital letters in original tweet (without any changes)
     if args.weekday:
+        # extract and one-hot-encode the weekday from the date of the tweet
         features.append(WeekdayExtractor(COLUMN_DATE))
 
     # create overall FeatureCollector

--- a/code/feature_extraction/extract_features.py
+++ b/code/feature_extraction/extract_features.py
@@ -17,7 +17,9 @@ from code.feature_extraction.mention_num import MentionNum
 from code.feature_extraction.token_length import TokenLength
 from code.feature_extraction.hashtag_num import HashtagNum
 from code.feature_extraction.url_num import URLsNum
-from code.util import COLUMN_TWEET, COLUMN_LABEL, COLUMN_HASHTAGS, COLUMN_MENTIONS, COLUMN_URLS
+from code.feature_extraction.tweet_language import TweetLanguage
+from code.feature_extraction.weekday_extractor import WeekdayExtractor
+from code.util import COLUMN_TWEET, COLUMN_LABEL, COLUMN_HASHTAGS, COLUMN_MENTIONS, COLUMN_URLS, COLUMN_DATE
 
 # setting up CLI
 parser = argparse.ArgumentParser(description="Feature Extraction")
@@ -30,6 +32,7 @@ parser.add_argument("-t", "--token_length", action="store_true", help="compute t
 parser.add_argument("--hashtag_num", action="store_true", help="compute the number hashtags in the tweet")
 parser.add_argument("-m", "--mention_num", action="store_true", help="compute the number of mentions in the tweet")
 parser.add_argument("-u", "--url_num", action="store_true", help="compute the number of URLs in the tweet")
+parser.add_argument("-w", "--weekday", action="store_true", help="extract the one-hot encoded weekday of the tweet's date")
 args = parser.parse_args()
 
 # load data
@@ -59,6 +62,8 @@ else:  # need to create FeatureCollector manually
     if args.url_num:
         # number of URLs of original tweet data from urls column
         features.append(URLsNum(COLUMN_URLS))
+    if args.weekday:
+        features.append(WeekdayExtractor(COLUMN_DATE))
 
     # create overall FeatureCollector
     feature_collector = FeatureCollector(features)

--- a/code/feature_extraction/feature_collector.py
+++ b/code/feature_extraction/feature_collector.py
@@ -10,6 +10,7 @@ Created on Wed Sep 29 12:36:01 2021
 
 import numpy as np
 from code.feature_extraction.feature_extractor import FeatureExtractor
+from code.util import flatten
 
 # extend FeatureExtractor for the sake of simplicity
 class FeatureCollector(FeatureExtractor):
@@ -53,4 +54,4 @@ class FeatureCollector(FeatureExtractor):
         feature_names = []
         for feature in self._features:
             feature_names.append(feature.get_feature_name())
-        return feature_names
+        return flatten(feature_names)

--- a/code/feature_extraction/weekday_extractor.py
+++ b/code/feature_extraction/weekday_extractor.py
@@ -1,0 +1,42 @@
+"""
+Weekday feature extractor:
+Extracts the weekday of the posting date for each tweet
+"""
+import datetime
+import numpy as np
+from sklearn.preprocessing import OneHotEncoder
+
+from code.feature_extraction.feature_extractor import FeatureExtractor
+from code.util import COLUMN_DATE, ISO_WEEKDAYS
+
+
+# class for extracting the character-based length as a feature
+class WeekdayExtractor(FeatureExtractor):
+
+    # constructor
+    def __init__(self, input_column=COLUMN_DATE):
+        super().__init__([input_column], input_column)
+        self.encoder = OneHotEncoder()
+        self.feature_names = None
+
+    def get_feature_name(self):
+        return self.feature_names.tolist()
+
+    # don't need to fit, so don't overwrite _set_variables()
+
+    # compute the word length based on the inputs
+    def _get_values(self, inputs):
+        # Get weekdays from tweets
+        weekdays = []
+        for tweet in inputs[0]:
+            tweet_date = datetime.datetime.strptime(tweet, "%Y-%m-%d")
+            day_int = tweet_date.isoweekday()
+            weekdays.append(ISO_WEEKDAYS[day_int])
+        weekdays = np.array(weekdays)
+
+        # One-Hot encode the extracted weekday
+        self.encoder.fit(weekdays.reshape(-1, 1))
+        encoded = self.encoder.transform(weekdays.reshape(-1, 1)).toarray()
+        self.feature_names = self.encoder.get_feature_names(['weekday'])
+
+        return encoded

--- a/code/util.py
+++ b/code/util.py
@@ -15,6 +15,7 @@ COLUMN_RETWEETS = "retweets_count"
 COLUMN_HASHTAGS = "hashtags"
 COLUMN_MENTIONS = "mentions"
 COLUMN_URLS = "urls"
+COLUMN_DATE = "date"
 
 # column names of novel columns for preprocessing
 COLUMN_LABEL = "label"
@@ -26,3 +27,23 @@ SUFFIX_TOKEN_LENGTH = "_token_length"
 SUFFIX_HASHTAG_NUM = "_hashtag_num"
 SUFFIX_MENTION_NUM = "_mention_num"
 SUFFIX_URL_NUM = "_url_num"
+
+# Weekday dictionary
+ISO_WEEKDAYS = {1: "Mon",
+                2: "Tue",
+                3: "Wed",
+                4: "Thu",
+                5: "Fri",
+                6: "Sat",
+                7: "Sun"}
+
+
+def flatten(t):
+    flat_list = []
+    for sublist in t:
+        if isinstance(sublist, list):
+            for item in sublist:
+                flat_list.append(item)
+        else:
+            flat_list.append(sublist)
+    return flat_list

--- a/test/feature_extraction/weekday_extractor_test.py
+++ b/test/feature_extraction/weekday_extractor_test.py
@@ -1,0 +1,27 @@
+import unittest
+import pandas as pd
+
+from code.feature_extraction.weekday_extractor import WeekdayExtractor
+from code.util import COLUMN_DATE
+
+
+class WeekdayExtractorTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.INPUT_COLUMN = COLUMN_DATE
+        self.extractor = WeekdayExtractor(self.INPUT_COLUMN)
+
+    def test_weekday_extraction(self):
+        input = ['2021-10-16', '2021-10-15', '2021-10-08']
+        input_df = pd.DataFrame()
+        input_df[COLUMN_DATE] = input
+
+        # Expected columns would be weekday_Fri and weekday_Sat, thus only two one-hot-encoded values
+        expected_output = [[0, 1], [1, 0], [1, 0]]
+        output = self.extractor.fit_transform(input_df)
+
+        self.assertEqual(expected_output, output.tolist())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The weekday will be extracted from the date column using pythons `datetime` library and will be one-hot-encoded using `sklearn.preprocessing.OneHotEncoder`.

The resulting feature columns will have the prefix "weekday_" and the 3-letter abbreviations of the weekdays. E.g "weekday_Mon".

To have all the new columns in the output from the FeatureCollector, and to fit with its implementation, I added a utility function in `util.py` called `flatten()` which makes this possible 