### PR TITLE
Fixes TokenLength input column

### DIFF
--- a/code/feature_extraction/extract_features.py
+++ b/code/feature_extraction/extract_features.py
@@ -21,7 +21,7 @@ from code.feature_extraction.cap_letter_num import CapLettersNum
 from code.feature_extraction.punc_num import PunctuationNum
 from code.feature_extraction.weekday_extractor import WeekdayExtractor
 from code.util import COLUMN_TWEET, COLUMN_LABEL, COLUMN_HASHTAGS, COLUMN_MENTIONS, COLUMN_URLS, COLUMN_DATE, \
-    SUFFIX_TOKENIZED
+    SUFFIX_TOKENIZED, COLUMN_STOPWORDS
 
 # setting up CLI
 parser = argparse.ArgumentParser(description="Feature Extraction")
@@ -57,6 +57,7 @@ else:  # need to create FeatureCollector manually
     if args.token_length:
         # token length of tokenized tweet
         features.append(TokenLength(COLUMN_TWEET + SUFFIX_TOKENIZED))
+        features.append(TokenLength(COLUMN_STOPWORDS))
     if args.hashtag_num:
         # number of hashtags of original tweet data from hashtags column
         features.append(HashtagNum(COLUMN_HASHTAGS))

--- a/code/feature_extraction/extract_features.py
+++ b/code/feature_extraction/extract_features.py
@@ -20,7 +20,8 @@ from code.feature_extraction.url_num import URLsNum
 from code.feature_extraction.cap_letter_num import CapLettersNum
 from code.feature_extraction.punc_num import PunctuationNum
 from code.feature_extraction.weekday_extractor import WeekdayExtractor
-from code.util import COLUMN_TWEET, COLUMN_LABEL, COLUMN_HASHTAGS, COLUMN_MENTIONS, COLUMN_URLS, COLUMN_DATE
+from code.util import COLUMN_TWEET, COLUMN_LABEL, COLUMN_HASHTAGS, COLUMN_MENTIONS, COLUMN_URLS, COLUMN_DATE, \
+    SUFFIX_TOKENIZED
 
 # setting up CLI
 parser = argparse.ArgumentParser(description="Feature Extraction")
@@ -54,8 +55,8 @@ else:  # need to create FeatureCollector manually
         # character length of original tweet (without any changes)
         features.append(CharacterLength(COLUMN_TWEET))
     if args.token_length:
-        # word/token length of original tweet (without any changes)
-        features.append(TokenLength(COLUMN_TWEET))
+        # token length of tokenized tweet
+        features.append(TokenLength(COLUMN_TWEET + SUFFIX_TOKENIZED))
     if args.hashtag_num:
         # number of hashtags of original tweet data from hashtags column
         features.append(HashtagNum(COLUMN_HASHTAGS))

--- a/code/feature_extraction/token_length.py
+++ b/code/feature_extraction/token_length.py
@@ -27,7 +27,6 @@ class TokenLength(FeatureExtractor):
             nums_of_tokens.append(len(token_list))
 
         nums_of_tokens = np.array(nums_of_tokens).reshape(-1, 1)
-        print(nums_of_tokens)
 
         return nums_of_tokens
         # token_lengths = []

--- a/code/feature_extraction/token_length.py
+++ b/code/feature_extraction/token_length.py
@@ -2,6 +2,7 @@
 Token length feature extractor:
 Extracts the length of tokens for each tweet
 """
+import ast
 import numpy as np
 
 from code.feature_extraction.feature_extractor import FeatureExtractor
@@ -19,11 +20,21 @@ class TokenLength(FeatureExtractor):
 
     # compute the word length based on the inputs
     def _get_values(self, inputs):
-        token_lengths = []
+        nums_of_tokens = []
 
         for tweet in inputs[0]:
-            token_lengths.append(len(tweet.split()))
+            token_list = ast.literal_eval(tweet)
+            nums_of_tokens.append(len(token_list))
 
-        token_lengths = np.array(token_lengths).reshape(-1, 1)
+        nums_of_tokens = np.array(nums_of_tokens).reshape(-1, 1)
+        print(nums_of_tokens)
 
-        return token_lengths
+        return nums_of_tokens
+        # token_lengths = []
+        #
+        # for tweet in inputs[0]:
+        #     token_lengths.append(len(tweet.split()))
+        #
+        # token_lengths = np.array(token_lengths).reshape(-1, 1)
+        #
+        # return token_lengths

--- a/test/feature_extraction/token_length_test.py
+++ b/test/feature_extraction/token_length_test.py
@@ -11,8 +11,8 @@ class TokenLengthTest(unittest.TestCase):
         self.extractor = TokenLength(self.INPUT_COLUMN)
 
     def test_character_length(self):
-        input_text = "This is an example sentence which is to be tokenized and counted"
-        output = [12]
+        input_text = "['This', 'is', 'an', 'example', 'sentence']"
+        output = [5]
 
         input_df = pd.DataFrame()
         input_df[self.INPUT_COLUMN] = [input_text]

--- a/test/feature_extraction/token_length_test.py
+++ b/test/feature_extraction/token_length_test.py
@@ -10,7 +10,7 @@ class TokenLengthTest(unittest.TestCase):
         self.INPUT_COLUMN = "input"
         self.extractor = TokenLength(self.INPUT_COLUMN)
 
-    def test_character_length(self):
+    def test_token_length(self):
         input_text = "['This', 'is', 'an', 'example', 'sentence']"
         output = [5]
 


### PR DESCRIPTION
The TokenLength feature extractor now makes use of the tweet_tokenized column from the preprocessing step to count the tokens. 

Additionally, we also compute the TokenLength of the tweet once the stopwords have been removed. 
We might need to check if we need to assure that this Column exists. 