### PR TITLE
Fixes small counting error in for loop and missing reset

### DIFF
--- a/code/feature_extraction/cap_letter_num.py
+++ b/code/feature_extraction/cap_letter_num.py
@@ -23,14 +23,15 @@ class CapLettersNum(FeatureExtractor):
     # compute the number of capital letters in input
     def _get_values(self, inputs):
         cap_letter_num = []
-        number = 0
+
         for tweet in inputs[0]:
+            number = 0
             for character in tweet:
                 if character.isupper():
                     number = number + 1
-        cap_letter_num.append(number)
+            cap_letter_num.append(number)
 
-        cap_letter_num = np.array(cap_letter_num).reshape(-1,1)
+        cap_letter_num = np.array(cap_letter_num).reshape(-1, 1)
 
         return cap_letter_num
 

--- a/code/feature_extraction/punc_num.py
+++ b/code/feature_extraction/punc_num.py
@@ -22,12 +22,13 @@ class PunctuationNum(FeatureExtractor):
     # compute the number of punctuation characters in input
     def _get_values(self, inputs):
         punc_num = []
-        number = 0
+
         for tweet in inputs[0]:
+            number = 0
             for character in tweet:
                 if character in punctuation:
                     number = number + 1
-        punc_num.append(number)
+            punc_num.append(number)
 
         punc_num = np.array(punc_num).reshape(-1, 1)
         return punc_num


### PR DESCRIPTION
Before the extractor was just counting the respective feature for the last tweet since the indentation was slightly off. 
Additionally, the number had to be reset to 0 after every tweet, otherwise, we would not have counted from 0 at each tweet